### PR TITLE
Hide sidebar if #sidebar has no children

### DIFF
--- a/javascripts/theme.js
+++ b/javascripts/theme.js
@@ -11,15 +11,21 @@
       "autofocus.time_entry": true
     };
 
-    var sidebar_btn = $('<div id="sidebar_btn">&nbsp;</div>'),
+    var sidebar_btn = $('<div id="sidebar_btn">&nbsp;</div>'),                                                                                                                    
         elem = $('#main:not(.nosidebar) #sidebar');
 
     sidebar_btn.on('click', toggle_sidebar);
 
-    if (elem != undefined){
-      elem.before(sidebar_btn);
-      if ($.cookie('hide_sidebar') == 'yes'){
-        $('#main').toggleClass('nosidebar');
+    if (elem.length){
+      // show sidebar if it has something.
+      if ($("#sidebar").children().length) {
+          elem.before(sidebar_btn);
+          if ($.cookie('hide_sidebar') == 'yes'){
+            $('#main').toggleClass('nosidebar');
+          }   
+      } else {
+          // if #sidebar is empty, hide it completely.
+          $("#main").toggleClass("nosidebar");
       }
     }
 


### PR DESCRIPTION
I test it on redmine 2.3.4. Without this fix, redmine will show some extra blank on the right side if the page doesn't have sidebar.
