### PR TITLE
Fix the Profile Picture display size

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -984,7 +984,8 @@ div.wiki dl {
 }
 h2 img.gravatar {
   vertical-align: top;
-  width: 21px;
+  width: 48px;
+  height: 48px;
 }
 .contextual input[type='text'] {
   margin: 0;

--- a/stylesheets/application.less
+++ b/stylesheets/application.less
@@ -658,7 +658,8 @@ div.wiki {
 
 h2 img.gravatar {
   vertical-align: top;
-  width: 21px;
+  width: 48px;
+  height: 48px;
 }
 
 .contextual {


### PR DESCRIPTION
On the profile page of a user, the profile picture is displayed like this:
![profilepicturebug](https://cloud.githubusercontent.com/assets/3718398/5601404/4e42eedc-92fd-11e4-9a4a-7ab30f74bf5f.PNG)

This pull requests fixes this and sets the height and width to a fixed 48px to display it correctly:
![profilepicturebugfixed](https://cloud.githubusercontent.com/assets/3718398/5601409/85460a4a-92fd-11e4-8584-8ad516ca1839.PNG)
